### PR TITLE
wrap double bang coerced statements with parenthesis 

### DIFF
--- a/application/profile/user_settings.js
+++ b/application/profile/user_settings.js
@@ -88,10 +88,10 @@ class UserSettings extends React.Component{
   }
   _testErrors(){
     let {location, summary, firstName, lastName} = this.state;
-    if (!! location &&
-        summary != '' &&
-        firstName != '' &&
-        lastName != ''
+    if (!! (location &&
+            summary != '' &&
+            firstName != '' &&
+            lastName != '')
     ) {
       this.setState({formError: ''})
     }

--- a/application/ui_helpers/member_header.js
+++ b/application/ui_helpers/member_header.js
@@ -37,7 +37,7 @@ export default class MemberHeader extends React.Component{
     };
   }
   _setMaxHeight(event){
-    if (!! event.nativeEvent && event.nativeEvent.layout.height > this.state.maxHeight){
+    if (!! (event.nativeEvent && event.nativeEvent.layout.height > this.state.maxHeight)){
       this.setState({
         maxHeight: event.nativeEvent.layout.height,
         measured: true,

--- a/application/ui_helpers/summary.js
+++ b/application/ui_helpers/summary.js
@@ -37,7 +37,7 @@ export default class Summary extends React.Component{
     };
   }
   _setMaxHeight(event){
-    if (!! event.nativeEvent && event.nativeEvent.layout.height > this.state.maxHeight){
+    if (!! (event.nativeEvent && event.nativeEvent.layout.height > this.state.maxHeight)){
       this.setState({
         maxHeight: event.nativeEvent.layout.height,
         measured: true,

--- a/application/welcome/register.js
+++ b/application/welcome/register.js
@@ -76,11 +76,11 @@ export default class Register extends Component{
   }
   _testErrors(){
     let {location, email, password, firstName, lastName} = this.state;
-    if (!! location &&
-        email != '' &&
-        password != '' &&
-        firstName != '' &&
-        lastName != ''
+    if (!! (location &&
+            email != '' &&
+            password != '' &&
+            firstName != '' &&
+            lastName != '')
     ) {
       this.setState({formError: ''})
     }

--- a/index.ios.js
+++ b/index.ios.js
@@ -49,7 +49,7 @@ class assembly extends Component {
         if (DEV) {console.log('USER PARAMS', userParams);}
         let parsedUser = JSON.parse(userParams);
         if (DEV) {console.log('USER PARAMS', parsedUser);}
-        if (!! parsedUser && parsedUser.username && parsedUser.password){
+        if (!! (parsedUser && parsedUser.username && parsedUser.password)){
           let errors = null;
           if (DEV) {console.log("LOGIN", `${BASE_URL}/users/login`)}
           fetch(`${BASE_URL}/users/login`, {


### PR DESCRIPTION
when coercing a string of && statements, they must be themselves be wrapped in parenthesis as a collection so they're evaluated as a unit. 
