### PR TITLE
fix logic error, unless I'm misunderstanding

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -90,7 +90,7 @@ class assembly extends Component {
         }
       } else {
         if (DEV) {console.log('COULD NOT FIND USER');}
-        this.setState({foundUser: true})
+        this.setState({foundUser: false})
       }
     } catch (error) {
       if (DEV) {console.log('ERR: ', error)}


### PR DESCRIPTION
would make sense that `foundUser: false` if `COULD NOT FIND USER`. I considered also changing the logout to `COULD NOT FIND USER IN LOCALSTORAGE`. Let me know if you want me to roll that in as well. 
