### PR TITLE
Added react-native-cli installation instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 - Assemblies is an open-source mobile app built with `React Native` which developers can use to connect through 'assemblies' in their area.
-- The app is the basis for a tutorial on `React Native` at [www.buildreactnative.com](http://www.buildreactnative.com) though the actual app will contain features that are not covered in the tutorial.
+- The app is the basis for a tutorial on `React Native` at [www.buildreactnative.com](http://www.buildreactnative.com) though the actual app will contain features not covered in the tutorial.
 
 ## Screenshots
 
@@ -20,12 +20,13 @@
 ## Running locally
 
 - Here are the steps to running the app locally on your machine.
-  - Make sure you're running at least node version 4.0.0 - you can check your node version by running ```node -v``` in your terminal
+  - Make sure you're running, at least, node version 4.0.0 - you can check your node version by running ```node -v``` in your terminal
   - `git clone https://github.com/buildreactnative/assemblies`
   - `cd assemblies`
   - `npm install`
   - `open ios/assembly.xcworkspace`
-  - before you run the app, you have to create a file `Keys.plist` - this is what the main file `AppDelegate.m` uses to load analytics. Without the file Xcode will throw an error if you try to run. So in the main `assembly` folder, click `file` > `new` > `File...` > then select `Resource` => `Property List`, and title it `Keys.plist`. In the file, add a key `SEGMENT_API_KEY` and give it the value of any string. Make sure that `Keys.plist` doesn't get commited to git (you can place this file in a `.gitignore` file)
+  - before you run the app, you have to create a file `Keys.plist` - this is what the main file `AppDelegate.m` uses to load analytics. Without the file, Xcode will throw an error if you try to run. So in the main `assembly` folder, click `file` > `new` > `File...` > then select `Resource` => `Property List`, and title it `Keys.plist`. In the file, add a key `SEGMENT_API_KEY` and give it the value of any string. Make sure that `Keys.plist` doesn't get committed to git (you can place this file in a `.gitignore` file).
+  - Install react-native-cli `npm install -g react-native-cli`. Its recommended to be installed globally.
   - choose which simulator you would like to use and hit the `run` button in Xcode
 
 ## Things to test and improve


### PR DESCRIPTION
Without native-cli application won't work.
For the beginner, it's necessary to know.
